### PR TITLE
chore: (minor) Add better error messaging for CLI and improve quickstart docs

### DIFF
--- a/.changeset/long-points-know.md
+++ b/.changeset/long-points-know.md
@@ -1,0 +1,5 @@
+---
+"@empiricalrun/cli": patch
+---
+
+Better error messaging for CLI commands

--- a/.changeset/long-points-know.md
+++ b/.changeset/long-points-know.md
@@ -2,4 +2,4 @@
 "@empiricalrun/cli": patch
 ---
 
-Better error messaging for CLI commands
+chore: better error messaging for CLI commands

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -35,14 +35,21 @@ Our test will succeed if the model outputs valid JSON.
   </Step>
 
   <Step title="Run the test">
+    This step requires an `OPENAI_API_KEY` to authenticate with OpenAI.
+    
+    Create a `.env` file with `OPENAI_API_KEY` as environment variable.
+
+    ```sh
+    touch .env && echo "OPENAI_API_KEY=your_api_key_here" > .env
+    ```
+
     Run the test samples against the models with the `run` command.
 
     ```sh
     npx @empiricalrun/cli run
     ```
 
-    This step requires the `OPENAI_API_KEY` environment variable to authenticate with
-    OpenAI. This execution will cost $0.0026, based on the selected models.
+    This execution will cost ~$0.0026, based on the selected models.
   </Step>
 
   <Step title="See results">
@@ -57,7 +64,7 @@ Our test will succeed if the model outputs valid JSON.
   <Step title="[Bonus] Fix GPT-4 Turbo">
     GPT-4 Turbo tends to fail our JSON syntax check, because it returns outputs
    in markdown syntax (with backticks ` ```json `). We can fix this behavior by enabling
-   [JSON mode](https://platform.openai.com/docs/guides/text-generation/json-mode).
+   [JSON mode](https://platform.openai.com/docs/guides/text-generation/json-mode) in `empiricalrc.json` file.
    
     ```json
     {

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -37,10 +37,10 @@ Our test will succeed if the model outputs valid JSON.
   <Step title="Run the test">
     This step requires an `OPENAI_API_KEY` to authenticate with OpenAI.
     
-    Create a `.env` file with `OPENAI_API_KEY` as environment variable.
+    Export `OPENAI_API_KEY` as an environment variable.
 
     ```sh
-    touch .env && echo "OPENAI_API_KEY=your_api_key_here" > .env
+    export "OPENAI_API_KEY=your_api_key_here"
     ```
 
     Run the test samples against the models with the `run` command.

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -70,15 +70,7 @@ program
     "Provide path to .env file to load environment variables",
   )
   .action(async (options) => {
-    // Check for either envFile in options or .env file or .env.local file
-    let {error} = dotenv.config({ path: options.envFile || ".env" });
-
-    // Check if environment variables exist
-    if(error){
-      console.log(buildErrorLog("Failed to load environment variables"));
-      console.log(`${yellow("Please create .env file with necessary environment variables")} \n${cyan('touch .env && echo "AI_PROVIDER_API_KEY=your_api_key_here" > .env')}`);
-      process.exit(1);
-    }
+    dotenv.config({ path: options.envFile || [".env.local", ".env"] });
     console.log(yellow("Initiating run..."));
 
     let data;
@@ -184,12 +176,11 @@ program
 
     // Check if ui command is executed before the run command. 
     try {
-        await fs.readFile(outputFilePath);
-      } catch (err) {
-        console.log(buildErrorLog(`Failed to read output file`));
-        console.log(`${yellow("Please ensure to execute run command first")} - ${cyan("npx @empiricalrun/cli run")}`);
-        process.exit(1);
-      }
+      await fs.readFile(outputFilePath);
+    } catch (err) {
+      console.log(`${yellow("Please ensure to execute run command first")} - ${cyan("npx @empiricalrun/cli run")}`);
+      process.exit(1);
+    }
     console.log(yellow("Initiating webapp..."));
     const app = express();
     const port =

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -75,7 +75,7 @@ program
 
     // Check if environment variables exist
     if(error){
-      console.log(`${red("[Error]")} Failed to load environment varibles`);
+      console.log(`${red("[Error]")} Failed to load environment variables`);
       console.log(`${yellow("Please create .env file with necessary environment variables")} \n${cyan('touch .env && echo "AI_PROVIDER_API_KEY=your_api_key_here" > .env')}`);
       process.exit(1);
     }

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -70,7 +70,15 @@ program
     "Provide path to .env file to load environment variables",
   )
   .action(async (options) => {
-    dotenv.config({ path: options.envFile || [".env.local", ".env"] });
+    // Check for either envFile in options or .env file or .env.local file
+    let {error} = dotenv.config({ path: options.envFile || ".env" });
+
+    // Check if environment variables exist
+    if(error){
+      console.log(`${red("[Error]")} Failed to load environment varibles`);
+      console.log(`${yellow("Please create .env file with necessary environment variables")} \n${cyan('touch .env && echo "AI_PROVIDER_API_KEY=your_api_key_here" > .env')}`);
+      process.exit(1);
+    }
     console.log(yellow("Initiating run..."));
 
     let data;
@@ -79,7 +87,7 @@ program
       data = await fs.readFile(configFileFullPath);
     } catch (err) {
       console.log(buildErrorLog(`Failed to read ${configFileName} file`));
-      console.log(yellow("Please ensure running init command first"));
+      console.log(`${yellow("Please ensure running init command first")} - ${cyan("npx @empiricalrun/cli init")}`);
       process.exit(1);
     }
 
@@ -173,6 +181,15 @@ program
     `${defaultWebUIPort}`,
   )
   .action(async (options) => {
+
+    // Check if ui command is executed before the run command. 
+    try {
+        await fs.readFile(outputFilePath);
+      } catch (err) {
+        console.log(buildErrorLog(`Failed to read output file`));
+        console.log(`${yellow("Please ensure to execute run command first")} - ${cyan("npx @empiricalrun/cli run")}`);
+        process.exit(1);
+      }
     console.log(yellow("Initiating webapp..."));
     const app = express();
     const port =

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -75,7 +75,7 @@ program
 
     // Check if environment variables exist
     if(error){
-      console.log(`${red("[Error]")} Failed to load environment variables`);
+      console.log(buildErrorLog("Failed to load environment variables"));
       console.log(`${yellow("Please create .env file with necessary environment variables")} \n${cyan('touch .env && echo "AI_PROVIDER_API_KEY=your_api_key_here" > .env')}`);
       process.exit(1);
     }
@@ -100,7 +100,7 @@ program
       dataset = await loadDataset(datasetConfig);
     } catch (error) {
       if (error instanceof DatasetError) {
-        console.log(`${red("[Error]")} ${error.message}`);
+        console.log(buildErrorLog(error.message));
         process.exit(1);
       } else {
         throw error;


### PR DESCRIPTION
This PR introduces better error messaging for CLI commands and improves the Quickstart docs

- Check for environment variables before executing runs
<img width="682" alt="Screenshot 2024-04-10 at 23 11 09" src="https://github.com/empirical-run/empirical/assets/9695866/0e5c0525-1274-4c14-99ac-de100e405345">

After
<img width="682" alt="Screenshot 2024-04-10 at 23 12 20" src="https://github.com/empirical-run/empirical/assets/9695866/f14c04b8-ca65-4124-90bd-1bc00c027e68">

- Check for `output.json` before running the `ui` command. UI opens with a loading screen and terminal throws a file not found error

<img width="682" alt="Screenshot 2024-04-10 at 23 10 08" src="https://github.com/empirical-run/empirical/assets/9695866/ff13bd63-2beb-46d5-897c-1fa27a28022d">
<img width="1552" alt="Screenshot 2024-04-10 at 23 10 24" src="https://github.com/empirical-run/empirical/assets/9695866/f01a526e-969d-4135-90e2-bb88d335a739">

After
<img width="682" alt="Screenshot 2024-04-10 at 23 12 00" src="https://github.com/empirical-run/empirical/assets/9695866/198ad9fe-fc4c-42ef-9585-720e3d693fee">

- Quickstart docs - Add a line to create a `.env` with `OPENAI_API_KEY` to make sure the first run is always successful than showing an error message `AI202: process.env.OPENAI_API_KEY is not set`

<img width="809" alt="Screenshot 2024-04-10 at 23 25 53" src="https://github.com/empirical-run/empirical/assets/9695866/ed1a1451-2c65-45b6-8bb0-ff37a904800e">
