### PR TITLE
feat(interactivity): add or remove sample rows in the ui

### DIFF
--- a/.changeset/brave-forks-eat.md
+++ b/.changeset/brave-forks-eat.md
@@ -1,0 +1,7 @@
+---
+"web": minor
+"@empiricalrun/types": patch
+"@empiricalrun/cli": patch
+---
+
+feat: add or remove samples and run them on the comparison ui

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { cn } from "../components/ui/lib";
 import { ThemeProvider } from "../components/ui/theme-provider";
+import { Toaster } from "../components/ui/toaster";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 export const metadata: Metadata = {
@@ -25,6 +26,7 @@ export default function RootLayout({
       >
         <ThemeProvider attribute="class" defaultTheme="dark">
           {children}
+          <Toaster />
         </ThemeProvider>
       </body>
     </html>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -102,10 +102,10 @@ export default function Page(): JSX.Element {
 
   const onClickRunOnAllModelsForSample = useCallback(
     (sample: DatasetSample) => {
-      const runsWithoutSample = runResults.filter(
+      const runsWithoutSampleOutput = runResults.filter(
         (run) => !run.samples.some((s) => s.dataset_sample_id === sample.id),
       );
-      executeRunsForSample(runsWithoutSample, sample);
+      executeRunsForSample(runsWithoutSampleOutput, sample);
     },
     [runResults],
   );

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -8,7 +8,7 @@ import { useRunResultTableView } from "../hooks/useRunResultTableView";
 import InViewElement from "../components/ui/in-view";
 import SampleCard from "../components/sample-card";
 import SampleOutputCard from "../components/sample-output-card";
-import { RunConfig } from "@empiricalrun/types";
+import { DatasetSample, RunConfig } from "@empiricalrun/types";
 import { RunDetails } from "../components/run-details";
 import { RunResult } from "../types";
 
@@ -23,6 +23,7 @@ export default function Page(): JSX.Element {
     addDatasetSample,
     removeDatasetSample,
     updateDatasetSampleInput,
+    executeRunsForSample,
   } = useRunResults();
   const { tableHeaders, getSampleCell, setActiveRun, activeRun } =
     useRunResultTableView({
@@ -98,6 +99,18 @@ export default function Page(): JSX.Element {
     [activeRun, removeRun],
   );
 
+  const onClickRunOnAllModelsForSample = useCallback(
+    (sample: DatasetSample) => {
+      executeRunsForSample(
+        runResults.filter(
+          (run) => !run.samples.some((s) => s.id === sample.id),
+        ),
+        sample,
+      );
+    },
+    [runResults],
+  );
+
   useEffect(() => {
     if (dataset?.samples && runHeaderRowRef.current) {
       updateComparisonTableHeight();
@@ -165,11 +178,10 @@ export default function Page(): JSX.Element {
                     <SampleCard
                       sample={inputSample!}
                       inputTabs={datasetInputNames}
-                      onSampleAdd={(sample) =>
-                        addDatasetSample(sample, dataset!)
-                      }
+                      onSampleAdd={(sample) => addDatasetSample(sample)}
                       onSampleInputUpdate={updateDatasetSampleInput}
                       onSampleRemove={(sample) => removeDatasetSample(sample)}
+                      onClickRunOnAllModels={onClickRunOnAllModelsForSample}
                     />
                   </div>
                   {sampleCells.map((sample, i) => (

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -20,6 +20,9 @@ export default function Page(): JSX.Element {
     executeRun,
     updateRunConfigForRun,
     removeRun,
+    addDatasetSample,
+    removeDatasetSample,
+    updateDatasetSampleInput,
   } = useRunResults();
   const { tableHeaders, getSampleCell, setActiveRun, activeRun } =
     useRunResultTableView({
@@ -162,6 +165,11 @@ export default function Page(): JSX.Element {
                     <SampleCard
                       sample={inputSample!}
                       inputTabs={datasetInputNames}
+                      onSampleAdd={(sample) =>
+                        addDatasetSample(sample, dataset!)
+                      }
+                      onSampleInputUpdate={updateDatasetSampleInput}
+                      onSampleRemove={(sample) => removeDatasetSample(sample)}
                     />
                   </div>
                   {sampleCells.map((sample, i) => (

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -103,7 +103,7 @@ export default function Page(): JSX.Element {
   const onClickRunOnAllModelsForSample = useCallback(
     (sample: DatasetSample) => {
       const runsWithoutSample = runResults.filter(
-        (run) => !run.samples.some((s) => s.id === sample.id),
+        (run) => !run.samples.some((s) => s.dataset_sample_id === sample.id),
       );
       executeRunsForSample(runsWithoutSample, sample);
     },
@@ -185,7 +185,6 @@ export default function Page(): JSX.Element {
                       onSampleInputUpdate={updateDatasetSampleInput}
                       onSampleRemove={(sample) => {
                         if (dataset?.samples.length === 1) {
-                          // TODO: toast is not working
                           toast.toast({
                             title: "Cannot remove the last sample",
                           });
@@ -194,7 +193,8 @@ export default function Page(): JSX.Element {
                         }
                       }}
                       onClickRunOnAllModels={onClickRunOnAllModelsForSample}
-                      hasMissingCompletion={hasMissingCompletion} // TODO: support edits (input sample different from output sample?)
+                      // TODO: show run button also when input is edited
+                      hasMissingCompletion={hasMissingCompletion}
                     />
                   </div>
                   {sampleCells.map((sample, i) => (

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -101,12 +101,10 @@ export default function Page(): JSX.Element {
 
   const onClickRunOnAllModelsForSample = useCallback(
     (sample: DatasetSample) => {
-      executeRunsForSample(
-        runResults.filter(
-          (run) => !run.samples.some((s) => s.id === sample.id),
-        ),
-        sample,
+      const runsWithoutSample = runResults.filter(
+        (run) => !run.samples.some((s) => s.id === sample.id),
       );
+      executeRunsForSample(runsWithoutSample, sample);
     },
     [runResults],
   );
@@ -168,6 +166,8 @@ export default function Page(): JSX.Element {
               (h) => getSampleCell(r, h.runResult)!,
             );
             const inputSample = dataset!.samples?.filter((s) => s.id === r)[0];
+            const hasMissingCompletion =
+              sampleCells.filter((s) => !s).length > 0;
             return (
               <InViewElement
                 key={`run-sample-${r}`}
@@ -182,6 +182,7 @@ export default function Page(): JSX.Element {
                       onSampleInputUpdate={updateDatasetSampleInput}
                       onSampleRemove={(sample) => removeDatasetSample(sample)}
                       onClickRunOnAllModels={onClickRunOnAllModelsForSample}
+                      hasMissingCompletion={hasMissingCompletion} // TODO: support edits (input sample different from output sample?)
                     />
                   </div>
                   {sampleCells.map((sample, i) => (

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,6 +11,7 @@ import SampleOutputCard from "../components/sample-output-card";
 import { DatasetSample, RunConfig } from "@empiricalrun/types";
 import { RunDetails } from "../components/run-details";
 import { RunResult } from "../types";
+import { useToast } from "../components/ui/use-toast";
 
 export default function Page(): JSX.Element {
   const {
@@ -126,6 +127,8 @@ export default function Page(): JSX.Element {
     updateComparisonTableHeight();
   }, [activeRun]);
 
+  const toast = useToast();
+
   return (
     <main className="relative h-screen">
       <PageHeader />
@@ -180,7 +183,16 @@ export default function Page(): JSX.Element {
                       inputTabs={datasetInputNames}
                       onSampleAdd={(sample) => addDatasetSample(sample)}
                       onSampleInputUpdate={updateDatasetSampleInput}
-                      onSampleRemove={(sample) => removeDatasetSample(sample)}
+                      onSampleRemove={(sample) => {
+                        if (dataset?.samples.length === 1) {
+                          // TODO: toast is not working
+                          toast.toast({
+                            title: "Cannot remove the last sample",
+                          });
+                        } else {
+                          removeDatasetSample(sample);
+                        }
+                      }}
                       onClickRunOnAllModels={onClickRunOnAllModelsForSample}
                       hasMissingCompletion={hasMissingCompletion} // TODO: support edits (input sample different from output sample?)
                     />

--- a/apps/web/components/json-as-tab.tsx
+++ b/apps/web/components/json-as-tab.tsx
@@ -144,8 +144,8 @@ export function JsonAsTab({
                       ? value
                       : JSON.stringify(value, null, 2)
                   }
-                  // language="json" // TODO(arjun): still seeing json issue
-                  readOnly={false} // TODO(arjun): editing is not saving to the dataset
+                  language="json"
+                  readOnly={false}
                   scrollable
                   onChange={(value) => onEditorContentUpdate?.(key, value!)}
                 />

--- a/apps/web/components/json-as-tab.tsx
+++ b/apps/web/components/json-as-tab.tsx
@@ -7,6 +7,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "./ui/sheet";
+import { PlusCircledIcon, MinusCircledIcon } from "@radix-ui/react-icons";
 import { Button } from "./ui/button";
 import { ArrowTopRightIcon } from "@radix-ui/react-icons";
 import CodeViewer from "./ui/code-viewer";
@@ -16,10 +17,16 @@ export function JsonAsTab({
   storeKey = "",
   data,
   defaultTabs,
+  onSampleAdd,
+  onSampleRemove,
+  onEditorContentUpdate,
 }: {
   storeKey: string;
   data: { [key: string]: any };
   defaultTabs?: string[];
+  onSampleAdd?: () => void;
+  onSampleRemove?: () => void;
+  onEditorContentUpdate?: (key: string, value: string) => void;
 }) {
   const tabs = useMemo(
     () => defaultTabs || Object.keys(data),
@@ -59,13 +66,33 @@ export function JsonAsTab({
                         ? activeTabValue
                         : JSON.stringify(activeTabValue, null, 2)
                     }
-                    readOnly
+                    readOnly // expand sheet is readonly
                     scrollable
                     language="json"
                   />
                 </div>
               </SheetContent>
             </Sheet>
+          )}
+          {onSampleAdd && (
+            <Button
+              variant={"link"}
+              size={"xs"}
+              onClick={() => onSampleAdd()}
+              className=" self-end justify-end p-0"
+            >
+              <PlusCircledIcon />
+            </Button>
+          )}
+          {onSampleRemove && (
+            <Button
+              variant={"link"}
+              size={"xs"}
+              onClick={() => onSampleRemove()}
+              className=" self-end justify-end p-0"
+            >
+              <MinusCircledIcon />
+            </Button>
           )}
         </>
       </div>
@@ -98,9 +125,10 @@ export function JsonAsTab({
                       ? value
                       : JSON.stringify(value, null, 2)
                   }
-                  language="json"
-                  readOnly
+                  // language="json"
+                  readOnly={false} // TODO: editing is not saving to the dataset
                   scrollable
+                  onChange={(value) => onEditorContentUpdate?.(key, value!)}
                 />
               </TabsContent>
             );

--- a/apps/web/components/json-as-tab.tsx
+++ b/apps/web/components/json-as-tab.tsx
@@ -7,7 +7,11 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "./ui/sheet";
-import { PlusCircledIcon, MinusCircledIcon } from "@radix-ui/react-icons";
+import {
+  TriangleRightIcon,
+  PlusCircledIcon,
+  MinusCircledIcon,
+} from "@radix-ui/react-icons";
 import { Button } from "./ui/button";
 import { ArrowTopRightIcon } from "@radix-ui/react-icons";
 import CodeViewer from "./ui/code-viewer";
@@ -20,6 +24,7 @@ export function JsonAsTab({
   onSampleAdd,
   onSampleRemove,
   onEditorContentUpdate,
+  onClickRunAll,
 }: {
   storeKey: string;
   data: { [key: string]: any };
@@ -27,6 +32,7 @@ export function JsonAsTab({
   onSampleAdd?: () => void;
   onSampleRemove?: () => void;
   onEditorContentUpdate?: (key: string, value: string) => void;
+  onClickRunAll?: () => void;
 }) {
   const tabs = useMemo(
     () => defaultTabs || Object.keys(data),
@@ -73,6 +79,17 @@ export function JsonAsTab({
                 </div>
               </SheetContent>
             </Sheet>
+          )}
+          {onClickRunAll && (
+            <Button
+              variant={"secondary"}
+              size={"xs"}
+              className="flex flex-row pl-1"
+              onClick={onClickRunAll}
+            >
+              <TriangleRightIcon width={18} height={18} />
+              <span>Run this row</span>
+            </Button>
           )}
           {onSampleAdd && (
             <Button
@@ -125,8 +142,8 @@ export function JsonAsTab({
                       ? value
                       : JSON.stringify(value, null, 2)
                   }
-                  // language="json"
-                  readOnly={false} // TODO: editing is not saving to the dataset
+                  // language="json" // TODO(arjun): still seeing json issue
+                  readOnly={false} // TODO(arjun): editing is not saving to the dataset
                   scrollable
                   onChange={(value) => onEditorContentUpdate?.(key, value!)}
                 />

--- a/apps/web/components/json-as-tab.tsx
+++ b/apps/web/components/json-as-tab.tsx
@@ -21,6 +21,7 @@ export function JsonAsTab({
   storeKey = "",
   data,
   defaultTabs,
+  showRunButton,
   onSampleAdd,
   onSampleRemove,
   onEditorContentUpdate,
@@ -29,6 +30,7 @@ export function JsonAsTab({
   storeKey: string;
   data: { [key: string]: any };
   defaultTabs?: string[];
+  showRunButton?: boolean;
   onSampleAdd?: () => void;
   onSampleRemove?: () => void;
   onEditorContentUpdate?: (key: string, value: string) => void;
@@ -80,7 +82,7 @@ export function JsonAsTab({
               </SheetContent>
             </Sheet>
           )}
-          {onClickRunAll && (
+          {onClickRunAll && showRunButton && (
             <Button
               variant={"secondary"}
               size={"xs"}

--- a/apps/web/components/sample-card.tsx
+++ b/apps/web/components/sample-card.tsx
@@ -10,9 +10,11 @@ export default function SampleCard({
   onSampleAdd,
   onSampleInputUpdate,
   onClickRunOnAllModels,
+  hasMissingCompletion,
 }: {
   sample: DatasetSample;
   inputTabs?: string[];
+  hasMissingCompletion: boolean;
   onSampleRemove?: (sample: DatasetSample) => void;
   onSampleAdd?: (sample: DatasetSample) => void;
   onSampleInputUpdate?: (
@@ -30,6 +32,7 @@ export default function SampleCard({
           storeKey="input"
           data={sample?.inputs}
           defaultTabs={inputTabs}
+          showRunButton={hasMissingCompletion}
           onSampleAdd={() => onSampleAdd?.(sample)}
           onSampleRemove={() => onSampleRemove?.(sample)}
           onEditorContentUpdate={(key: string, value: string) =>

--- a/apps/web/components/sample-card.tsx
+++ b/apps/web/components/sample-card.tsx
@@ -9,6 +9,7 @@ export default function SampleCard({
   onSampleRemove,
   onSampleAdd,
   onSampleInputUpdate,
+  onClickRunOnAllModels,
 }: {
   sample: DatasetSample;
   inputTabs?: string[];
@@ -18,8 +19,8 @@ export default function SampleCard({
     sampleId: string,
     newSampleInputs: DatasetSampleInputs,
   ) => void;
+  onClickRunOnAllModels: (sample: DatasetSample) => void;
 }) {
-  console.log("sample", sample);
   return (
     <Card
       className={`flex flex-1 flex-col rounded-md items-stretch border-zinc-900`}
@@ -31,12 +32,12 @@ export default function SampleCard({
           defaultTabs={inputTabs}
           onSampleAdd={() => onSampleAdd?.(sample)}
           onSampleRemove={() => onSampleRemove?.(sample)}
-          onEditorContentUpdate={(key: string, value: string) => {
-            console.log(key, value);
+          onEditorContentUpdate={(key: string, value: string) =>
             onSampleInputUpdate?.(sample.id, {
               [key]: value,
-            });
-          }}
+            })
+          }
+          onClickRunAll={() => onClickRunOnAllModels?.(sample)}
         />
         {!Object.keys(sample?.inputs).length && <ZeroStateSampleCard />}
       </CardContent>

--- a/apps/web/components/sample-card.tsx
+++ b/apps/web/components/sample-card.tsx
@@ -1,15 +1,25 @@
 import { Card, CardContent } from "./ui/card";
-import { DatasetSample } from "@empiricalrun/types";
+import { DatasetSample, DatasetSampleInputs } from "@empiricalrun/types";
 import ZeroStateSampleCard from "./zero-state-sample-card";
 import { JsonAsTab } from "./json-as-tab";
 
 export default function SampleCard({
   sample,
   inputTabs,
+  onSampleRemove,
+  onSampleAdd,
+  onSampleInputUpdate,
 }: {
   sample: DatasetSample;
   inputTabs?: string[];
+  onSampleRemove?: (sample: DatasetSample) => void;
+  onSampleAdd?: (sample: DatasetSample) => void;
+  onSampleInputUpdate?: (
+    sampleId: string,
+    newSampleInputs: DatasetSampleInputs,
+  ) => void;
 }) {
+  console.log("sample", sample);
   return (
     <Card
       className={`flex flex-1 flex-col rounded-md items-stretch border-zinc-900`}
@@ -19,6 +29,14 @@ export default function SampleCard({
           storeKey="input"
           data={sample?.inputs}
           defaultTabs={inputTabs}
+          onSampleAdd={() => onSampleAdd?.(sample)}
+          onSampleRemove={() => onSampleRemove?.(sample)}
+          onEditorContentUpdate={(key: string, value: string) => {
+            console.log(key, value);
+            onSampleInputUpdate?.(sample.id, {
+              [key]: value,
+            });
+          }}
         />
         {!Object.keys(sample?.inputs).length && <ZeroStateSampleCard />}
       </CardContent>

--- a/apps/web/components/ui/toast.tsx
+++ b/apps/web/components/ui/toast.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+import { Cross2Icon } from "@radix-ui/react-icons";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "./lib";
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className,
+    )}
+    toast-close=""
+    {...props}
+  >
+    <Cross2Icon className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold [&+div]:text-xs", className)}
+    {...props}
+  />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+};

--- a/apps/web/components/ui/toaster.tsx
+++ b/apps/web/components/ui/toaster.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "./toast";
+import { useToast } from "./use-toast";
+
+export function Toaster() {
+  const { toasts } = useToast();
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        );
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/apps/web/components/ui/use-toast.ts
+++ b/apps/web/components/ui/use-toast.ts
@@ -1,0 +1,189 @@
+// Inspired by react-hot-toast library
+import * as React from "react";
+
+import type { ToastActionElement, ToastProps } from "./toast";
+
+const TOAST_LIMIT = 1;
+const TOAST_REMOVE_DELAY = 1000000;
+
+type ToasterToast = ToastProps & {
+  id: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  action?: ToastActionElement;
+};
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const;
+
+let count = 0;
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER;
+  return count.toString();
+}
+
+type ActionType = typeof actionTypes;
+
+type Action =
+  | {
+      type: ActionType["ADD_TOAST"];
+      toast: ToasterToast;
+    }
+  | {
+      type: ActionType["UPDATE_TOAST"];
+      toast: Partial<ToasterToast>;
+    }
+  | {
+      type: ActionType["DISMISS_TOAST"];
+      toastId?: ToasterToast["id"];
+    }
+  | {
+      type: ActionType["REMOVE_TOAST"];
+      toastId?: ToasterToast["id"];
+    };
+
+interface State {
+  toasts: ToasterToast[];
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return;
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId);
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId: toastId,
+    });
+  }, TOAST_REMOVE_DELAY);
+
+  toastTimeouts.set(toastId, timeout);
+};
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      };
+
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t,
+        ),
+      };
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action;
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId);
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id);
+        });
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t,
+        ),
+      };
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        };
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      };
+  }
+};
+
+const listeners: Array<(state: State) => void> = [];
+
+let memoryState: State = { toasts: [] };
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action);
+  listeners.forEach((listener) => {
+    listener(memoryState);
+  });
+}
+
+type Toast = Omit<ToasterToast, "id">;
+
+function toast({ ...props }: Toast) {
+  const id = genId();
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: "UPDATE_TOAST",
+      toast: { ...props, id },
+    });
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id });
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss();
+      },
+    },
+  });
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  };
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState);
+
+  React.useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, [state]);
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  };
+}
+
+export { useToast, toast };

--- a/apps/web/hooks/useRunCompletion.ts
+++ b/apps/web/hooks/useRunCompletion.ts
@@ -70,7 +70,6 @@ export function useRunResults() {
     async (run: RunResult, dataset: Dataset) => {
       let runId = run.id;
       setLoadingStateForRun(runId, true);
-      run.loading = true;
       for await (const chunk of streamFetch("/api/runs/execute", {
         method: "POST",
         headers: {
@@ -253,14 +252,13 @@ export function useRunResults() {
     async (runs: RunResult[], sample: DatasetSample) => {
       runs.forEach(async (run) => {
         setLoadingStateForRun(run.id, true);
-        run.loading = true;
         for await (const chunk of streamFetch("/api/runs/execute-sample", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            run: { ...run.run_config, name: undefined },
+            run: run.run_config,
             sample,
           }),
         })) {

--- a/apps/web/hooks/useRunCompletion.ts
+++ b/apps/web/hooks/useRunCompletion.ts
@@ -189,13 +189,15 @@ export function useRunResults() {
 
   const addDatasetSample = useCallback(
     async (sample: DatasetSample) => {
-      console.log(sample); // TODO: this is not used
       setDataset((prevDataset) => {
         if (!prevDataset) {
           return prevDataset;
         }
         const { samples } = prevDataset;
-        // TODO: this assume there is at least one sample
+        const newSampleIdx = samples
+          .map((s, idx) => s.id === sample.id && idx + 1)
+          .find((x) => !!x) as number;
+        // TODO: Assuming there is at least one sample to infer input keys
         const inputs = Object.keys(samples[0]?.inputs || {}).reduce(
           (inputs: DatasetSampleInputs, key) => {
             inputs[key] = "";
@@ -209,7 +211,11 @@ export function useRunResults() {
         };
         return {
           ...prevDataset,
-          samples: [...samples, newSample],
+          samples: [
+            ...samples.slice(0, newSampleIdx),
+            newSample,
+            ...samples.slice(newSampleIdx),
+          ],
         };
       });
     },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
+    "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/apps/web/utils/index.ts
+++ b/apps/web/utils/index.ts
@@ -17,14 +17,14 @@ export function aggregateRunStats(
   return {
     outputs: sumObjectsByKey(oldStats?.outputs || {}, newStats.outputs),
     scores: newStats.scores.map((score) => {
-      const newScore = oldStats?.scores.find((s) => s.name === score.name);
-      const count = score.count + (newScore?.count || 0);
+      const oldScore = oldStats?.scores.find((s) => s.name === score.name);
+      const count = score.count + (oldScore?.count || 0);
       return {
         name: score.name,
         count,
         avgScore:
           (score.count * score.avgScore +
-            (newScore?.count || 0) * (newScore?.avgScore || 0)) /
+            (oldScore?.count || 0) * (oldScore?.avgScore || 0)) /
           count,
       };
     }),

--- a/apps/web/utils/index.ts
+++ b/apps/web/utils/index.ts
@@ -41,13 +41,12 @@ export function statsAfterRemoved(
   }
   const { scores, outputs } = stats;
   const foundSample = samples.find((s) => s.dataset_sample_id === sample.id);
-  const changeInSuccess = foundSample && foundSample.output.value ? 1 : 0;
-  const changeInFailed = foundSample && !foundSample.output.value ? 1 : 0;
+  const keyToChange = foundSample && foundSample.error ? "failed" : "success";
   return {
     outputs: {
-      count: outputs.count - 1,
-      success: outputs.success - changeInSuccess,
-      failed: outputs.failed - changeInFailed,
+      ...outputs,
+      count: foundSample ? outputs.count - 1 : outputs.count,
+      [keyToChange]: outputs[keyToChange] - 1,
     },
     scores: scores.map((score) => {
       const foundScore =

--- a/apps/web/utils/index.ts
+++ b/apps/web/utils/index.ts
@@ -1,0 +1,70 @@
+import { DatasetSample, RunCompletionStats } from "@empiricalrun/types";
+import { RunResult } from "../types";
+
+function sumObjectsByKey(...objs: any[]) {
+  return objs.reduce((a, b) => {
+    for (let k in b) {
+      if (Object.prototype.hasOwnProperty.call(b, k)) a[k] = (a[k] || 0) + b[k];
+    }
+    return a;
+  }, {});
+}
+
+export function aggregateRunStats(
+  newStats: RunCompletionStats,
+  oldStats: RunCompletionStats | undefined,
+): RunCompletionStats {
+  return {
+    outputs: sumObjectsByKey(oldStats?.outputs || {}, newStats.outputs),
+    scores: newStats.scores.map((score) => {
+      const newScore = oldStats?.scores.find((s) => s.name === score.name);
+      const count = score.count + (newScore?.count || 0);
+      return {
+        name: score.name,
+        count,
+        avgScore:
+          (score.count * score.avgScore +
+            (newScore?.count || 0) * (newScore?.avgScore || 0)) /
+          count,
+      };
+    }),
+  };
+}
+
+export function statsAfterRemoved(
+  run: RunResult,
+  sample: DatasetSample,
+): RunCompletionStats | undefined {
+  const { stats, samples } = run;
+  if (!stats) {
+    return stats;
+  }
+  const { scores, outputs } = stats;
+  const foundSample = samples.find((s) => s.dataset_sample_id === sample.id);
+  const changeInSuccess = foundSample && foundSample.output.value ? 1 : 0;
+  const changeInFailed = foundSample && !foundSample.output.value ? 1 : 0;
+  return {
+    outputs: {
+      count: outputs.count - 1,
+      success: outputs.success - changeInSuccess,
+      failed: outputs.failed - changeInFailed,
+    },
+    scores: scores.map((score) => {
+      const foundScore =
+        foundSample &&
+        foundSample.scores?.find(({ name }) => name === score.name);
+      let { count, avgScore } = score;
+      if (foundScore) {
+        const oldTotal = avgScore * count;
+        count = count - 1;
+        const newTotal = oldTotal - foundScore.score;
+        avgScore = newTotal / count;
+      }
+      return {
+        ...score,
+        count,
+        avgScore,
+      };
+    }),
+  };
+}

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -218,7 +218,10 @@ program
         runs: RunConfig[];
         dataset: Dataset;
       };
+      // stream - check for ids - to tell which object is updated
       const streamUpdate = (obj: any) => res.write(JSON.stringify(obj) + `\n`);
+
+      // this runs the first run
       const completion = await execute(runs[0]!, dataset, streamUpdate);
       setRunSummary([completion]);
       const statsUpdate: RunStatsUpdate = {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -166,7 +166,7 @@ export type RunSampleOutput = {
   id?: string;
   annotations?: string[];
   scores?: Score[];
-  inputs: { [key: string]: string };
+  inputs: DatasetSampleInputs;
   output: RunOutput;
   expected?: {
     value: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -122,9 +122,11 @@ export interface RunCompletion {
   created_at: Date;
 }
 
+export type DatasetSampleInputs = { [key: string]: string };
+
 export type DatasetSample = {
   id: string;
-  inputs: { [key: string]: string };
+  inputs: DatasetSampleInputs;
   expected?: string;
 };
 
@@ -135,7 +137,7 @@ export type Dataset = {
 
 export type DatasetSampleConfig = {
   id?: string;
-  inputs: { [key: string]: string };
+  inputs: DatasetSampleInputs;
   expected?: string;
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -58,6 +62,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.0.4
         version: 1.0.4(@types/react-dom@18.2.19)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-toast':
+        specifier: ^1.1.5
+        version: 1.1.5(@types/react-dom@18.2.19)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-tooltip':
         specifier: ^1.0.7
         version: 1.0.7(@types/react-dom@18.2.19)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0)
@@ -1765,6 +1772,38 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-toast@1.1.5(@types/react-dom@18.2.19)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-fRLn227WHIBRSzuRzGJ8W+5YALxofH23y0MlPLddaIpLpCDqdE0NZlS2NRQDRiptfxDeeCjgFIpexB1/zkxDlw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.0
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.61)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.61)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.19)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.2.19)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.19)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.61)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.61)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.61)(react@18.2.0)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.61
+      '@types/react-dom': 18.2.19
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-tooltip@1.0.7(@types/react-dom@18.2.19)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-lPh5iKNFVQ/jav/j6ZrWq3blfDJ0OH9R6FlNUHPMqdLuQ9vwDgFsRxvl8b7Asuy5c8xmoojHUxKHQSOAvMHxyw==}
     peerDependencies:
@@ -2586,7 +2625,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.29.0)
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.17.0)(eslint-plugin-import@2.29.0)(eslint@8.57.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@7.1.0)(eslint@8.57.0)
       eslint-plugin-jest: 27.6.0(@typescript-eslint/eslint-plugin@6.17.0)(eslint@8.57.0)(typescript@5.3.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-playwright: 0.16.0(eslint-plugin-jest@27.6.0)(eslint@8.57.0)
@@ -3778,7 +3817,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@7.1.0)(eslint@8.57.0)
     dev: true
 
   /eslint-import-resolver-node@0.3.9:
@@ -3801,8 +3840,8 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@7.1.0)(eslint@8.57.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -3814,7 +3853,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3838,8 +3877,36 @@ packages:
       '@typescript-eslint/parser': 6.17.0(eslint@8.57.0)(typescript@5.3.3)
       debug: 3.2.7
       eslint: 8.57.0
-      eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.17.0)(eslint-plugin-import@2.29.0)(eslint@8.57.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@7.1.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 7.1.0(eslint@8.57.0)(typescript@5.3.3)
+      debug: 3.2.7
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3855,7 +3922,7 @@ packages:
       ignore: 5.3.1
     dev: true
 
-  /eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  /eslint-plugin-import@2.29.0(@typescript-eslint/parser@7.1.0)(eslint@8.57.0):
     resolution: {integrity: sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3865,7 +3932,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.17.0(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.57.0)(typescript@5.3.3)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -3874,7 +3941,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.1.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -7896,7 +7963,3 @@ packages:
       which: 3.0.1
       yaml: 2.4.1
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
Open to dos
- [x] add new run experience is broken - stuck on loading
- [x] toast is not working for scenario where user is attempting to remove last sample
- [x] sample row is added at the end of the ui (not after the current sample)
- [ ] (zero sample playground) current implementation only works when one sample exists (from dataset config) and a new one is added
- [x] show "run button" when the sample is edited (not just when outputs are empty)
   - done in #127 
- [x] test on all examples to cover all scenarios
- [x] add change set 