### PR TITLE
chore: change name of google api key

### DIFF
--- a/.changeset/itchy-ads-crash.md
+++ b/.changeset/itchy-ads-crash.md
@@ -1,0 +1,5 @@
+---
+"@empiricalrun/ai": patch
+---
+
+chore: change api key name for google models

--- a/docs/models/basics.mdx
+++ b/docs/models/basics.mdx
@@ -54,7 +54,7 @@ See [dataset](../dataset/basics) to learn more about sample inputs.
 | `openai` | All chat models are supported. Requires `OPENAI_API_KEY` environment variable. |
 | `anthropic` | Claude 3 models are supported. Requires `ANTHROPIC_API_KEY` environment variable. |
 | `mistral` | All chat models are supported. Requires `MISTRAL_API_KEY` environment variable. |
-| `google` | Gemini Pro models are supported. Requires `GEMINI_API_KEY` environment variable. |
+| `google` | Gemini Pro models are supported. Requires `GOOGLE_API_KEY` environment variable. |
 | `fireworks` | Models hosted on Fireworks (e.g. `dbrx-instruct`) are supported. Requires `FIREWORKS_API_KEY` environment variable. |
 
 ### Environment variables

--- a/packages/ai/src/providers/google/index.ts
+++ b/packages/ai/src/providers/google/index.ts
@@ -54,14 +54,14 @@ const massageOpenAIMessagesToGoogleAI = function (
 };
 
 const createChatCompletion: ICreateChatCompletion = async (body) => {
-  if (!process.env.GEMINI_API_KEY) {
+  if (!process.env.GOOGLE_API_KEY) {
     throw new AIError(
       AIErrorEnum.MISSING_PARAMETERS,
-      "process.env.GEMINI_API_KEY is not set",
+      "process.env.GOOGLE_API_KEY is not set",
     );
   }
   const { model, messages } = body;
-  const googleAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
+  const googleAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY!);
   const modelInstance = googleAI.getGenerativeModel({ model });
   const contents = massageOpenAIMessagesToGoogleAI(messages);
   const { executionDone } = await batch.waitForTurn();

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "globalDependencies": ["**/.env.*local"],
   "globalEnv": [
     "MISTRAL_API_KEY",
-    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "FIREWORKS_API_KEY",
@@ -16,7 +16,7 @@
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**"],
       "env": [
-        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
         "MISTRAL_API_KEY",
         "OPENAI_API_KEY",
         "ANTHROPIC_API_KEY"


### PR DESCRIPTION
changing from GEMINI_API_KEY to GOOGLE_API_KEY to be consistent with [their cookbook](https://github.com/google-gemini/cookbook) and other docs