### PR TITLE
[chatbot example] - CLI summary doesn't show the second score - personal #167

### DIFF
--- a/packages/cli/src/stats/index.ts
+++ b/packages/cli/src/stats/index.ts
@@ -25,7 +25,13 @@ function runStatsSummary(
   enableColors: boolean,
 ): string[][] {
   // TODO: should get rid of this once config has separate scorer object
-  const scorerNames = runs[0]?.stats?.scores.map((s) => s.name) || [];
+  const scorerNames = [
+    ...new Set(
+      runs.flatMap(
+        (run) => run?.stats?.scores?.map((score) => score.name) || [],
+      ),
+    ),
+  ];
   const rows = [
     [
       " ",
@@ -56,7 +62,7 @@ function runStatsSummary(
               ? setMetricColor(metric, scoreStats.average)
               : metric;
           } else {
-            return percentStr(0);
+            return "-";
           }
         }),
       ]);


### PR DESCRIPTION
two things are done first 
1. all the scorer names are taken out , instead of assuming that first run will have all the jobs as done previously in your code .
` const scorerNames = [
    ...new Set(
      runs.flatMap(
        (run) => run?.stats?.scores?.map((score) => score.name) || [],
      ),
    ),
  ];`

2. then if their is no score then is should show "-" instead of "0% "
`if (scoreStats) {
            const metric = percentStr(scoreStats.average * 100);
            return enableColors
              ? setMetricColor(metric, scoreStats.average)
              : metric;
          } else {
            return "-";
          }`